### PR TITLE
Fix chat embedder css display issues

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1367,7 +1367,7 @@ footer { position: relative; z-index: 1; }
 .settings-drawer input#chatWidth, .settings-drawer input#chatHeight { width: 110px; }
 .settings-drawer input#desktopBgImage { min-width: 160px; max-width: 380px; flex: 1 1 220px; }
 
-header, .settings-drawer, .embed-controls, .section-header { position: relative; z-index: 10; }
+header, .embed-controls, .section-header { position: relative; z-index: 10; }
 /* header stacking reset above is redundant; keeping settings-drawer own z-index */
 
 .settings-drawer .row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 8px 0; }


### PR DESCRIPTION
Fix chat embedder settings being hidden by removing `.settings-drawer` from an incorrect `z-index` reset rule.

---
<a href="https://cursor.com/background-agent?bcId=bc-75e67081-5e03-4da3-825b-3690f01fdcb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75e67081-5e03-4da3-825b-3690f01fdcb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

