### PR TITLE
Customize chat glow and shadow colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -677,7 +677,7 @@ document.addEventListener('DOMContentLoaded', function() {
             height: desktop.height,
             z: ++zCounter,
             collapsed: false,
-            style: { borderColor: '', glowColor: '#000000' }
+            style: { borderColor: '', glowColor: '' }
         };
         createChatWindow(initialState);
         upsertWindowState(initialState);
@@ -740,6 +740,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (action === 'close') {
                 el.parentElement && el.parentElement.removeChild(el);
                 deleteWindowState(state.id);
+                rebuildChatStyleChips();
             } else if (action === 'toggle') {
                 el.classList.toggle('hidden-content');
                 state.collapsed = el.classList.contains('hidden-content');
@@ -1747,7 +1748,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const value = w.style?.borderColor || w.style?.glowColor || '#000000';
             chip.innerHTML = `
                 <span class="chip-title">${w.name}</span>
-                <label>Color</label>
+                <label>Glow</label>
                 <input type="color" value="${value}" data-kind="both" data-id="${w.id}">
             `;
             chatStylesList.appendChild(chip);
@@ -1757,8 +1758,11 @@ document.addEventListener('DOMContentLoaded', function() {
     function applyChatStyleToElement(el, style) {
         if (style?.borderColor) el.style.boxShadow = `0 0 0 2px ${style.borderColor}`;
         else el.style.boxShadow = '';
-        if (style?.glowColor) el.style.filter = `drop-shadow(0 0 8px ${style.glowColor})`;
-        else el.style.filter = '';
+        if (style?.glowColor) {
+            el.style.filter = `drop-shadow(0 2px 10px rgba(0,0,0,0.22)) drop-shadow(0 0 10px ${style.glowColor})`;
+        } else {
+            el.style.filter = '';
+        }
     }
 
     let styleChipsWired = false;

--- a/styles.css
+++ b/styles.css
@@ -1480,4 +1480,4 @@ header, .embed-controls, .section-header { position: relative; z-index: 10; }
 .chat-style-chip { display: flex; align-items: center; gap: 10px; padding: 6px 10px; border: var(--border); border-radius: 10px; margin: 6px 0; background: var(--card-bg); }
 .chat-style-chip .chip-title { font-weight: 600; color: var(--text); min-width: 120px; }
 .chat-style-chip label { color: var(--text-light); font-size: 0.9rem; }
-.chat-style-chip input[type="color"] { flex: 0 0 auto; }
+.chat-style-chip input[type="color"] { flex: 0 0 auto; width: 40px; height: 32px; padding: 0; border: none; border-radius: 6px; }


### PR DESCRIPTION
Add per-chat glow color customization with a single hex selector.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4fb7702-ab22-465e-8caf-d113a29b6f0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4fb7702-ab22-465e-8caf-d113a29b6f0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

