### PR TITLE
Implement xatspace gallery code modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,10 +354,19 @@
                   /* Modal */
                   #xatspace-templates .modal-backdrop{position:fixed; inset:0; background:rgba(0,0,0,.6); display:none; align-items:center; justify-content:center; opacity:0; transition:opacity .2s ease; z-index:9999}
                   #xatspace-templates .modal-backdrop.open{display:flex; opacity:1}
-                  #xatspace-templates .modal{background:var(--card-bg); border:var(--border); border-radius:14px; width:min(680px, 92vw); padding:16px; box-shadow:0 20px 60px rgba(0,0,0,.5); transform:scale(.96); opacity:0; transition:transform .2s ease, opacity .2s ease}
+                  #xatspace-templates .modal{background:var(--card-bg); border:var(--border); border-radius:14px; width:min(680px, 92vw); padding:24px; box-shadow:0 20px 60px rgba(0,0,0,.5); transform:scale(.96); opacity:0; transition:transform .2s ease, opacity .2s ease; position:relative; max-height:90vh; display:flex; flex-direction:column}
                   #xatspace-templates .modal-backdrop.open .modal{transform:scale(1); opacity:1}
-                  #xatspace-templates .codebox{background: #0f1429; border:1px solid rgba(255,255,255,.08); border-radius:8px; padding:10px; max-height:260px; overflow:auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.85rem; color: var(--text)}
-                  #xatspace-templates .row{display:flex; gap:8px; justify-content:flex-end; margin-top:10px}
+                  #xatspace-templates .modal-x{position:absolute; top:12px; right:12px; width:32px; height:32px; border:none; background:rgba(255,255,255,.08); color:var(--text-light); border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; font-size:18px; line-height:1; transition:var(--transition); z-index:1}
+                  #xatspace-templates .modal-x:hover{background:rgba(255,255,255,.15); color:var(--text); transform:scale(1.05)}
+                  #xatspace-templates .modal h3{margin:0 32px 16px 0; font-size:1.2rem; color:var(--text)}
+                  #xatspace-templates .codebox{background: #0f1429; border:1px solid rgba(255,255,255,.08); border-radius:8px; padding:16px; flex:1; overflow:auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.85rem; color: var(--text); line-height:1.5; white-space:pre-wrap; word-break:break-all}
+                  #xatspace-templates .row{display:flex; gap:8px; justify-content:flex-end; margin-top:16px; flex-shrink:0}
+                  @media (max-width: 600px) { #xatspace-templates .modal{width:95vw; padding:20px; max-height:85vh} #xatspace-templates .codebox{font-size:.8rem; padding:12px} }
+                  /* Scrollbar styling for codebox */
+                  #xatspace-templates .codebox::-webkit-scrollbar{width:8px;height:8px}
+                  #xatspace-templates .codebox::-webkit-scrollbar-thumb{background:linear-gradient(180deg,#6c5ce7,#8b7cf6);border-radius:999px}
+                  #xatspace-templates .codebox::-webkit-scrollbar-track{background:rgba(255,255,255,.06)}
+                  #xatspace-templates .codebox{scrollbar-width:thin; scrollbar-color:#6c5ce7 rgba(255,255,255,.06)}
                   /* Match site scrollbar style inside previews */
                   #xatspace-templates .template-preview iframe::-webkit-scrollbar{width:8px;height:8px}
                   #xatspace-templates .template-preview iframe::-webkit-scrollbar-thumb{background:linear-gradient(180deg,#6c5ce7,#8b7cf6);border-radius:999px}
@@ -374,7 +383,7 @@
                             <p>Synthwave neon glow with gallery lightbox</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-neon/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-neon"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-neon"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -387,7 +396,7 @@
                             <p>Stars and debris swirl into a cursor-driven singularity</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-blackhole/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-blackhole"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-blackhole"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -400,7 +409,7 @@
                             <p>CRT scanlines, typing cursor headings</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-terminal/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-terminal"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-terminal"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -413,7 +422,7 @@
                             <p>Content-first with clean typography</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-minimal/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-minimal"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-minimal"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -426,7 +435,7 @@
                             <p>Layered gradient blobs with parallax</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-parallax/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-parallax"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-parallax"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -439,7 +448,7 @@
                             <p>8-bit pixel borders with bitmap font</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-retro/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-retro"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-retro"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -452,7 +461,7 @@
                             <p>Prism borders and tilt hypercards</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-holo/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-holo"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-holo"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -465,7 +474,7 @@
                             <p>Animated wave-grid background</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-gridwave/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-gridwave"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-gridwave"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>
@@ -478,7 +487,7 @@
                             <p>Orbiting friend nodes around avatar</p>
                             <div class="template-actions">
                                 <a href="xatspace/template-orbit/index.html" class="primary-btn no-underline" target="_blank"><i class="fas fa-eye"></i> View Live</a>
-                                <button class="link-btn" data-code="template-orbit"><i class="fas fa-code"></i> View Code</button>
+                                <button class="link-btn" data-code="template-orbit"><i class="fas fa-download"></i> Download</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Changes "View Code" buttons to "Download" and enhances modal styling for xatspace galleries.

---
<a href="https://cursor.com/background-agent?bcId=bc-9aab6e08-89ae-4f76-a97d-d314d17b6c1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9aab6e08-89ae-4f76-a97d-d314d17b6c1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

