### PR TITLE
Prevent bold formatting in xat code output

### DIFF
--- a/script.js
+++ b/script.js
@@ -1425,7 +1425,6 @@ document.addEventListener('DOMContentLoaded', function() {
         effectPreview.style.setProperty('--glow-color', glow);
         let code = '(glow';
         code += `#${glow.replace('#', '')}`;
-        if (effectPreview.classList.contains('bold')) code += '#b';
         if (colors.length > 1) {
             code += `#grad#r${angle}`;
             if (speed) code += `#${speed}`;


### PR DESCRIPTION
Remove `#b` from the xat code output when bold is selected in the namegrad section, as bold is intended for visual preview only.

---
<a href="https://cursor.com/background-agent?bcId=bc-2af83dd7-47ae-4eb3-9589-3312b5cf4ae3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2af83dd7-47ae-4eb3-9589-3312b5cf4ae3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

